### PR TITLE
Add configurable buffer policies

### DIFF
--- a/src/buffer_policy/buffer_age_policy.rs
+++ b/src/buffer_policy/buffer_age_policy.rs
@@ -1,0 +1,65 @@
+use std::time::{Duration, Instant};
+
+use super::{BufferInstruction, BufferPolicy};
+
+/// A buffer policy that limits the buffer to a certain age.
+#[derive(Debug, Clone, Copy)]
+pub struct BufferAgePolicy<T, F> {
+    age_limit: Duration,
+    get_timestamp: F,
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T, F: Fn(&T) -> Instant> BufferAgePolicy<T, F> {
+    /// Create a new buffer age policy.
+    ///
+    /// Timestamps retrieved from the items are compared to the age limit. When
+    /// the tail is older than age_limit, it is popped.
+    pub fn new(age_limit: Duration, get_timestamp: F) -> Self {
+        Self {
+            age_limit,
+            get_timestamp,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T, F: Fn(&T) -> Instant> BufferPolicy<T> for BufferAgePolicy<T, F> {
+    fn buffer_tail_policy(&mut self, tail_item: &T) -> BufferInstruction {
+        if self.age_limit < (self.get_timestamp)(tail_item).elapsed() {
+            log::debug!("Popping item due to age limit");
+            BufferInstruction::Pop
+        } else {
+            log::debug!("Retaining tail due to low age");
+            BufferInstruction::Retain
+        }
+    }
+
+    fn on_before_send(&mut self, _new_item: &mut T) {
+        // No bookkeeping needed.
+    }
+
+    fn on_after_pop(&mut self, _popped_item: &mut T) {
+        // No bookkeeping needed.
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::time::{Duration, Instant};
+
+    use crate::buffer_policy::{BufferAgePolicy, BufferInstruction, BufferPolicy};
+
+    #[test]
+    fn test() {
+        let time = Instant::now();
+        let mut policy = BufferAgePolicy::new(Duration::from_secs(1), |_: &usize| time);
+
+        assert_eq!(policy.buffer_tail_policy(&0), BufferInstruction::Retain);
+
+        let time = time - Duration::from_secs(2);
+        let mut policy = BufferAgePolicy::new(Duration::from_secs(1), |_: &usize| time);
+
+        assert_eq!(policy.buffer_tail_policy(&0), BufferInstruction::Pop);
+    }
+}

--- a/src/buffer_policy/buffer_length_policy.rs
+++ b/src/buffer_policy/buffer_length_policy.rs
@@ -1,0 +1,62 @@
+use super::{BufferInstruction, BufferPolicy};
+
+/// A buffer policy that limits the buffer to a certain length.
+#[derive(Debug, Clone, Copy)]
+pub struct BufferLengthPolicy {
+    limit: usize,
+    count: usize,
+}
+
+impl BufferLengthPolicy {
+    /// Create a new buffer length policy.
+    pub fn new(limit: usize) -> Self {
+        Self { limit, count: 0 }
+    }
+}
+
+impl<T> BufferPolicy<T> for BufferLengthPolicy {
+    fn buffer_tail_policy(&mut self, _tail_item: &T) -> BufferInstruction {
+        if self.limit <= self.count {
+            log::debug!("Popping item due to length limit");
+            BufferInstruction::Pop
+        } else {
+            log::debug!("Retaining tail due to low length");
+            BufferInstruction::Retain
+        }
+    }
+
+    fn on_before_send(&mut self, _new_item: &mut T) {
+        self.count += 1;
+        log::debug!("length increased: new_length: {}", self.count);
+    }
+
+    fn on_after_pop(&mut self, _popped_item: &mut T) {
+        self.count -= 1;
+        log::debug!("length decreased: new_length: {}", self.count);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::buffer_policy::{BufferInstruction, BufferLengthPolicy, BufferPolicy};
+
+    #[test]
+    fn test() {
+        let mut policy = BufferLengthPolicy::new(2);
+
+        assert_eq!(policy.buffer_tail_policy(&0), BufferInstruction::Retain);
+        policy.on_before_send(&mut 0);
+
+        assert_eq!(policy.buffer_tail_policy(&0), BufferInstruction::Retain);
+        policy.on_before_send(&mut 0);
+
+        assert_eq!(policy.buffer_tail_policy(&0), BufferInstruction::Pop);
+        policy.on_after_pop(&mut 0);
+        policy.on_before_send(&mut 0);
+
+        assert_eq!(policy.buffer_tail_policy(&0), BufferInstruction::Pop);
+        policy.on_after_pop(&mut 0);
+
+        assert_eq!(policy.buffer_tail_policy(&0), BufferInstruction::Retain);
+    }
+}

--- a/src/buffer_policy/buffer_weight_policy.rs
+++ b/src/buffer_policy/buffer_weight_policy.rs
@@ -1,0 +1,75 @@
+use super::{BufferInstruction, BufferPolicy};
+
+/// A buffer policy that limits the buffer to a certain weight.
+#[derive(Debug, Clone, Copy)]
+pub struct BufferWeightPolicy<T, F> {
+    weight_limit: usize,
+    weight: usize,
+    get_weight: F,
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T, F: Fn(&T) -> usize> BufferWeightPolicy<T, F> {
+    /// Create a new buffer weight policy.
+    ///
+    /// Weights retrieved from the items are compared to the weight limit. When
+    /// the buffer is heavier than weight_limit, the tail is popped.
+    ///
+    /// The weight limit is soft.
+    pub fn new(weight_limit: usize, get_weight: F) -> Self {
+        Self {
+            weight_limit,
+            weight: 0,
+            get_weight,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T, F: Fn(&T) -> usize> BufferPolicy<T> for BufferWeightPolicy<T, F> {
+    fn buffer_tail_policy(&mut self, _tail_item: &T) -> BufferInstruction {
+        if self.weight_limit < self.weight {
+            log::debug!("Popping item due to weight limit");
+            BufferInstruction::Pop
+        } else {
+            log::debug!("Retaining tail due to low weight");
+            BufferInstruction::Retain
+        }
+    }
+
+    fn on_before_send(&mut self, new_item: &mut T) {
+        self.weight = self.weight.saturating_add((self.get_weight)(new_item));
+        log::debug!("weight increased: new_weight: {}", self.weight);
+    }
+
+    fn on_after_pop(&mut self, popped_item: &mut T) {
+        self.weight = self.weight.saturating_sub((self.get_weight)(popped_item));
+        log::debug!("weight decreased: new_weight: {}", self.weight);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::buffer_policy::{BufferInstruction, BufferPolicy, BufferWeightPolicy};
+
+    #[test]
+    fn test() {
+        // just treat the new item as a weight
+        let mut policy = BufferWeightPolicy::new(2, |item: &usize| *item);
+
+        policy.on_before_send(&mut 0);
+        assert_eq!(policy.buffer_tail_policy(&0), BufferInstruction::Retain);
+
+        policy.on_before_send(&mut 1);
+        assert_eq!(policy.buffer_tail_policy(&1), BufferInstruction::Retain);
+
+        policy.on_before_send(&mut 2);
+        assert_eq!(policy.buffer_tail_policy(&2), BufferInstruction::Pop);
+
+        policy.on_after_pop(&mut 1);
+        assert_eq!(policy.buffer_tail_policy(&3), BufferInstruction::Retain);
+
+        policy.on_before_send(&mut 1);
+        assert_eq!(policy.buffer_tail_policy(&4), BufferInstruction::Pop);
+    }
+}

--- a/src/buffer_policy/composite_buffer_policy.rs
+++ b/src/buffer_policy/composite_buffer_policy.rs
@@ -1,0 +1,76 @@
+use super::{BufferInstruction, BufferPolicy};
+
+/// A buffer policy for joining buffer policies.
+///
+/// Composite policies only retain items that all policies agree to retain.
+/// If any policy says to pop, the item is popped.
+///
+/// The upper policy is checked first. If it says to pop, the item is popped.
+#[derive(Debug, Clone, Copy)]
+pub struct CompositeBufferPolicy<T, U> {
+    pub(super) upper: T,
+    pub(super) lower: U,
+}
+
+impl<T, PUpper, PLower> BufferPolicy<T> for CompositeBufferPolicy<PUpper, PLower>
+where
+    PUpper: BufferPolicy<T>,
+    PLower: BufferPolicy<T>,
+{
+    fn buffer_tail_policy(&mut self, tail_item: &T) -> BufferInstruction {
+        match self.upper.buffer_tail_policy(tail_item) {
+            BufferInstruction::Retain => {
+                log::debug!("Upper policy retained tail - checking lower policy");
+                match self.lower.buffer_tail_policy(tail_item) {
+                    BufferInstruction::Retain => {
+                        log::debug!("Lower policy retained tail - composite policy retains tail");
+                        BufferInstruction::Retain
+                    }
+                    BufferInstruction::Pop => {
+                        log::debug!("Lower policy pops tail - composite policy pops tail");
+                        BufferInstruction::Pop
+                    }
+                }
+            }
+            BufferInstruction::Pop => {
+                log::debug!("Upper policy pops tail - composite policy pops tail");
+                BufferInstruction::Pop
+            }
+        }
+    }
+
+    fn on_before_send(&mut self, new_item: &mut T) {
+        log::debug!("notifying policies of new item");
+        self.upper.on_before_send(new_item);
+        self.lower.on_before_send(new_item);
+    }
+
+    fn on_after_pop(&mut self, popped_item: &mut T) {
+        log::debug!("notifying policies of popped item");
+        self.upper.on_after_pop(popped_item);
+        self.lower.on_after_pop(popped_item);
+    }
+}
+
+/// Extension trait for building composite buffer policies.
+pub trait BufferPolicyExtension<T, PLower>
+where
+    PLower: BufferPolicy<T>,
+    Self: Sized,
+{
+    /// Wrap this buffer policy above a lower-priority buffer policy.
+    ///
+    /// Composite policies only retain items that all policies agree to retain.
+    /// If any policy says to pop, the item is popped.
+    fn wrap(self, lower: PLower) -> CompositeBufferPolicy<Self, PLower>;
+}
+
+impl<T, PUpper, PLower> BufferPolicyExtension<T, PLower> for PUpper
+where
+    PUpper: BufferPolicy<T>,
+    PLower: BufferPolicy<T>,
+{
+    fn wrap(self, lower: PLower) -> CompositeBufferPolicy<PUpper, PLower> {
+        CompositeBufferPolicy { upper: self, lower }
+    }
+}

--- a/src/buffer_policy/mod.rs
+++ b/src/buffer_policy/mod.rs
@@ -1,0 +1,11 @@
+mod buffer_age_policy;
+mod buffer_length_policy;
+mod buffer_weight_policy;
+mod composite_buffer_policy;
+mod policy_trait;
+
+pub use buffer_age_policy::BufferAgePolicy;
+pub use buffer_length_policy::BufferLengthPolicy;
+pub use buffer_weight_policy::BufferWeightPolicy;
+pub use composite_buffer_policy::{BufferPolicyExtension, CompositeBufferPolicy};
+pub use policy_trait::{BufferInstruction, BufferPolicy};

--- a/src/buffer_policy/policy_trait.rs
+++ b/src/buffer_policy/policy_trait.rs
@@ -1,0 +1,51 @@
+/// What to do when a new item is about to go into the channel.
+///
+/// This tells the buffer when to remove or retain items.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BufferInstruction {
+    /// Keep the tail as-is.
+    ///
+    /// This instruction causes the buffer to keep the tail item. You can use this
+    /// to tell the buffer how much to keep for subscribers.
+    Retain,
+    /// Remove the tail item.
+    ///
+    /// This instruction causes the buffer to remove the tail item, which will cause
+    /// after_pop() to be called with that tail item.
+    /// After after_pop() disposes of the tail item, before_send() is called again to
+    /// determine what to do with the new item.
+    Pop,
+}
+
+/// Determines when the buffer should pop or retain items.
+///
+/// This trait controls how the internal buffer is managed. If you pop the tail, you may
+/// leave some subscribers behind and cause lag messages. However, if you retain forever,
+/// you will run out of memory. This trait allows you to control the tradeoff.
+///
+/// You can look at the `buffer_policy` module for examples of how policies may be written,
+/// and implement your own policy as is appropriate for your own channel.
+pub trait BufferPolicy<T> {
+    /// This method is called to determine how the channel buffer should be managed.
+    fn buffer_tail_policy(&mut self, tail_item: &T) -> BufferInstruction;
+
+    /// Called to notify when a new item is committed to the buffer.
+    ///
+    /// This happens before the item is sent to subscribers. It is called from the synchronous
+    /// Engine context, so you get `&mut` access right before it becomes visible to subscribers.
+    /// This is the real original item, and alterations here will be visible to subscribers.
+    ///
+    /// Policies that do bookkeeping on items should do it here. This is called once for each item.
+    /// Policies may alter the item in place, e.g., to add a timestamp.
+    fn on_before_send(&mut self, new_item: &mut T);
+
+    /// Called to notify when an item is removed from the buffer.
+    ///
+    /// This happens after the item is removed from the buffer. It is called from the synchronous
+    /// Engine context, so you get `&mut` access to the item that was removed. It is a clone of
+    /// the original, however.
+    ///
+    /// Policies that do bookkeeping on items should do it here. This is called once for each item.
+    /// Policies may alter the item in place, but remember that this is just a clone of the original.
+    fn on_after_pop(&mut self, popped_item: &mut T);
+}

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -58,6 +58,14 @@ where
         }
     }
 
+    pub(crate) fn new_at_buffer_start(shared: Arc<Shared<Item>>) -> Self {
+        shared.increment_subscriber_count();
+        Self {
+            next_message_id: shared.subscribe_tail_sequence_number(),
+            shared,
+        }
+    }
+
     fn mark_clean_and_register_for_wake(&mut self, context: &mut Context<'_>) {
         self.shared.register_waker(WakeHandle::new(
             self.next_message_id,


### PR DESCRIPTION
This change elevates the internal buffer into an extensible api.
You can configure any combination of policies, including defining
your own. A common set of policies are included here; namely,
* CompositeBufferPolicy: A policy that joins policies
* BufferAgePolicy: Evicts messages older than a threshold
* BufferLengthPolicy: Evicts messages when there are more than a threshold
* BufferWeightPolicy: Evicts messages when they accumulate too much size or weight.
